### PR TITLE
Fix issue with AT+CPSI in GSM mode

### DIFF
--- a/src/commands/cpsi.rs
+++ b/src/commands/cpsi.rs
@@ -10,7 +10,7 @@ impl AtCommand for Cpsi {
     const COMMAND: &'static str = "AT+CPSI";
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SystemMode {
     NoService,
     Gsm,
@@ -18,7 +18,7 @@ pub enum SystemMode {
     LteNbIot,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum OperationMode {
     Online,
     Offline,
@@ -27,7 +27,7 @@ pub enum OperationMode {
     LowPower,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SystemInfo {
     pub system_mode: SystemMode,
     pub operation_mode: OperationMode,
@@ -42,7 +42,7 @@ impl AtDecode for SystemInfo {
 
         let mut components = decoder.remainder_str(timeout)?.split(',');
 
-        let system_mode = match components.next().ok_or(crate::Error::DecodingFailed)? {
+        let system_mode = match components.next().unwrap() {
             "NO SERVICE" => SystemMode::NoService,
             "GSM" => SystemMode::Gsm,
             "LTE CAT-M1" => SystemMode::LteCatM1,
@@ -50,7 +50,7 @@ impl AtDecode for SystemInfo {
             _ => return Err(crate::Error::DecodingFailed),
         };
 
-        let operation_mode = match components.next().ok_or(crate::Error::DecodingFailed)? {
+        let operation_mode = match components.next().unwrap() {
             "Online" => OperationMode::Online,
             "Offline" => OperationMode::Offline,
             "Factory Test Mode" => OperationMode::FactoryTest,
@@ -60,8 +60,25 @@ impl AtDecode for SystemInfo {
         };
 
         decoder.end_line();
-        decoder.expect_empty(timeout)?;
+        decoder.expect_empty(timeout).unwrap();
         decoder.end_line();
+
+        // The SIM7000 may respond with either one or two empty lines before the "OK" depending on if it is in LTE or GSM mode.
+        match decoder.remainder_str(timeout)? {
+            "OK" => {
+                decoder.expect_str("OK", timeout)?;
+                return Ok(SystemInfo {
+                    system_mode,
+                    operation_mode,
+                });
+            }
+            "" => {
+                decoder.expect_empty(timeout)?;
+                decoder.end_line();
+            }
+            _ => return Err(Error::DecodingFailed),
+        }
+
         decoder.expect_str("OK", timeout)?;
 
         Ok(SystemInfo {
@@ -73,4 +90,56 @@ impl AtDecode for SystemInfo {
 
 impl AtRead for Cpsi {
     type Output = SystemInfo;
+}
+
+#[cfg(test)]
+mod test {
+    use embedded_time::duration::Milliseconds;
+
+    use crate::{commands::AtRead, test::MockSerial};
+
+    use super::{Cpsi, OperationMode, SystemInfo, SystemMode};
+
+    #[test]
+    fn test_gsm_response() {
+        let mut mock = MockSerial::build()
+            .expect_write(b"AT+CPSI?\r")
+            .expect_read(b"")
+            .expect_read(b"+CPSI: GSM,Online,240-01,0x11a4,25882,80 EGSM 900,-89,0,22-22")
+            .expect_read(b"")
+            .expect_read(b"")
+            .expect_read(b"OK")
+            .finalize();
+
+        let response = Cpsi.read(&mut mock, Milliseconds(1000)).unwrap();
+
+        assert_eq!(
+            response,
+            SystemInfo {
+                system_mode: SystemMode::Gsm,
+                operation_mode: OperationMode::Online
+            }
+        )
+    }
+
+    #[test]
+    fn test_lte_response() {
+        let mut mock = MockSerial::build()
+            .expect_write(b"AT+CPSI?\r")
+            .expect_read(b"")
+            .expect_read(b"+CPSI: LTE CAT-M1,Online,240-01,0x0081,25716767,254,EUTRAN-BAND3,1300,5,5,-13,-84,-54,18")
+            .expect_read(b"")
+            .expect_read(b"OK")
+            .finalize();
+
+        let response = Cpsi.read(&mut mock, Milliseconds(1000)).unwrap();
+
+        assert_eq!(
+            response,
+            SystemInfo {
+                system_mode: SystemMode::LteCatM1,
+                operation_mode: OperationMode::Online
+            }
+        )
+    }
 }


### PR DESCRIPTION
The sim7000 has a bug where in GSM mode the AT+CPSI command will respond
with two newlines after the informational line instead of just one.
Change the parser to be able to handle this and add tests to prevent
regression.