### PR TITLE
Redesign line reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ edition = "2021"
 [dependencies]
 embedded-time = "0.12"
 heapless = "0.7"
+lazy_static = {version = "1.4", features = ["spin_no_std"] }
 embedded-hal = "0.2"
 log = "0.4"

--- a/src/commands/ccid.rs
+++ b/src/commands/ccid.rs
@@ -53,8 +53,6 @@ impl AtDecode for Iccid {
         };
 
         decoder.end_line();
-        decoder.expect_empty(timeout)?;
-        decoder.end_line();
         decoder.expect_str("OK", timeout)?;
 
         Ok(result)

--- a/src/commands/cgmr.rs
+++ b/src/commands/cgmr.rs
@@ -31,8 +31,6 @@ impl AtDecode for CgmrResponse {
 
         decoder.end_line();
 
-        decoder.expect_empty(timeout)?;
-        decoder.end_line();
         decoder.expect_str("OK", timeout)?;
 
         Ok(result)

--- a/src/commands/cgnscpy.rs
+++ b/src/commands/cgnscpy.rs
@@ -32,8 +32,6 @@ impl AtDecode for CopyResult {
         };
 
         decoder.end_line();
-        decoder.expect_empty(timeout)?;
-        decoder.end_line();
         decoder.expect_str("OK", timeout)?;
 
         Ok(result)

--- a/src/commands/cgnsinf.rs
+++ b/src/commands/cgnsinf.rs
@@ -102,8 +102,6 @@ impl AtDecode for GnssResponse {
             .ok_or(crate::Error::DecodingFailed)?;
 
         decoder.end_line();
-        decoder.expect_empty(timeout)?;
-        decoder.end_line();
         decoder.expect_str("OK", timeout)?;
 
         Ok(result)

--- a/src/commands/cgnspwr.rs
+++ b/src/commands/cgnspwr.rs
@@ -34,7 +34,6 @@ impl AtDecode for PowerStatus {
             _ => return Err(crate::Error::DecodingFailed),
         };
 
-        decoder.expect_empty(timeout)?;
         decoder.end_line();
         decoder.expect_str("OK", timeout)?;
 

--- a/src/commands/cgreg.rs
+++ b/src/commands/cgreg.rs
@@ -62,8 +62,6 @@ impl AtDecode for RegistrationResponse {
         };
 
         decoder.end_line();
-        decoder.expect_empty(timeout)?;
-        decoder.end_line();
         decoder.expect_str("OK", timeout)?;
 
         Ok(RegistrationResponse { mode, stat })

--- a/src/commands/cntp.rs
+++ b/src/commands/cntp.rs
@@ -68,8 +68,6 @@ impl AtDecode for CntpResponse {
     ) -> Result<Self, crate::Error<B::SerialError>> {
         decoder.expect_str("OK", timeout)?;
         decoder.end_line();
-        decoder.expect_empty(timeout)?;
-        decoder.end_line();
 
         Ok(match decoder.decode_scalar(timeout)? {
             1 => {

--- a/src/commands/cops.rs
+++ b/src/commands/cops.rs
@@ -72,8 +72,6 @@ impl AtDecode for OperatorInfo {
             .into();
 
         decoder.end_line();
-        decoder.expect_empty(timeout)?;
-        decoder.end_line();
         decoder.expect_str("OK", timeout)?;
 
         Ok(OperatorInfo {

--- a/src/commands/cpsi.rs
+++ b/src/commands/cpsi.rs
@@ -60,10 +60,8 @@ impl AtDecode for SystemInfo {
         };
 
         decoder.end_line();
-        decoder.expect_empty(timeout)?;
-        decoder.end_line();
 
-        // The SIM7000 may respond with either one or two empty lines before the "OK" depending on if it is in LTE or GSM mode.
+        // The SIM7000 may respond with an extra empty line in GSM mode for no reason
         match decoder.remainder_str(timeout)? {
             "OK" => {
                 decoder.expect_str("OK", timeout)?;
@@ -73,7 +71,6 @@ impl AtDecode for SystemInfo {
                 });
             }
             "" => {
-                decoder.expect_empty(timeout)?;
                 decoder.end_line();
             }
             _ => return Err(Error::DecodingFailed),
@@ -104,11 +101,9 @@ mod test {
     fn test_gsm_response() {
         let mut mock = MockSerial::build()
             .expect_write(b"AT+CPSI?\r")
-            .expect_read(b"")
-            .expect_read(b"+CPSI: GSM,Online,240-01,0x11a4,25882,80 EGSM 900,-89,0,22-22")
-            .expect_read(b"")
-            .expect_read(b"")
-            .expect_read(b"OK")
+            .expect_read(b"\r\n+CPSI: GSM,Online,240-01,0x11a4,25882,80 EGSM 900,-89,0,22-22\r\n")
+            .expect_read(b"\r\n\r\n")
+            .expect_read(b"\r\nOK\r\n")
             .finalize();
 
         let response = Cpsi.read(&mut mock, Milliseconds(1000)).unwrap();
@@ -126,10 +121,8 @@ mod test {
     fn test_lte_response() {
         let mut mock = MockSerial::build()
             .expect_write(b"AT+CPSI?\r")
-            .expect_read(b"")
-            .expect_read(b"+CPSI: LTE CAT-M1,Online,240-01,0x0081,25716767,254,EUTRAN-BAND3,1300,5,5,-13,-84,-54,18")
-            .expect_read(b"")
-            .expect_read(b"OK")
+            .expect_read(b"\r\n+CPSI: LTE CAT-M1,Online,240-01,0x0081,25716767,254,EUTRAN-BAND3,1300,5,5,-13,-84,-54,18\r\n")
+            .expect_read(b"\r\nOK\r\n")
             .finalize();
 
         let response = Cpsi.read(&mut mock, Milliseconds(1000)).unwrap();

--- a/src/commands/csq.rs
+++ b/src/commands/csq.rs
@@ -63,8 +63,6 @@ impl AtDecode for SignalDiagnostics {
 
         decoder.end_line();
 
-        decoder.expect_empty(timeout)?;
-        decoder.end_line();
         decoder.expect_str("OK", timeout)?;
 
         Ok(SignalDiagnostics {


### PR DESCRIPTION
The current line reader was horribly broken. The redesign makes the
reader match the datasheet more closely. Insead of reading until \r\n
and returning all text up until then, the new reader finds the leading
\r\n that preceeds all sim7000 lines. It then reads up to the following
\r\n to terminate the line. This resolves intermittent issues with echo
as well as some unsolicited result codes.