### PR TITLE
fix: Add release system base on semver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,14 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Tests / Lint / Coverage
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-  workflow_dispatch:
+   push:
+     branches:
+     - "**"
+   pull_request:
+     branches:
+     - "**"
 
 jobs:
   check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - alpha
+      - beta
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'technocreatives/sim7000'
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+    
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release
+    
+    - name: release
+      uses: cycjimmy/semantic-release-action@v2
+      id: semantic
+      with:
+        semantic_version: 17.1.1
+        extra_plugins: |
+          @semantic-release/exec@5.0
+          @semantic-release/git@9.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,16 @@
+branches:
+  - main
+  - name: beta
+    prerelease: true
+  - name: alpha
+    prerelease: true
+
+plugins:
+    - '@semantic-release/commit-analyzer'
+    - '@semantic-release/release-notes-generator'
+    - '@semantic-release/github'
+    - - '@semantic-release/exec'
+      - prepareCmd: "cargo install cargo-bump && cargo bump ${nextRelease.version}"
+        publishCmd: "cargo publish -vv"
+    - - '@semantic-release/git'
+      - assets: Cargo.toml


### PR DESCRIPTION
Here a sample of CI to use if you want to deliver a library on crate.io and docs.rs.

You will need to configure a `GH_TOKEN` with `public_repo` right.

You will need to configure `CARGO_REGISTRY_TOKEN` too, https://crates.io/settings/tokens, it's here to create a new token for the project.