### PR TITLE
Log improvements

### DIFF
--- a/sim7000-async/src/at_command/at.rs
+++ b/sim7000-async/src/at_command/at.rs
@@ -2,6 +2,8 @@ use heapless::String;
 
 use super::{AtRequest, GenericOk};
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct At;
 
 impl AtRequest for At {

--- a/sim7000-async/src/at_command/ate.rs
+++ b/sim7000-async/src/at_command/ate.rs
@@ -3,6 +3,8 @@ use heapless::String;
 use super::{AtRequest, GenericOk};
 
 /// ATE1 / ATE0
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct SetEcho(pub bool);
 
 impl AtRequest for SetEcho {

--- a/sim7000-async/src/at_command/cbatchk.rs
+++ b/sim7000-async/src/at_command/cbatchk.rs
@@ -3,6 +3,8 @@ use heapless::String;
 use super::{AtRequest, GenericOk};
 
 /// AT+CBATCHK=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct EnableVBatCheck(pub bool);
 
 impl AtRequest for EnableVBatCheck {

--- a/sim7000-async/src/at_command/ccid.rs
+++ b/sim7000-async/src/at_command/ccid.rs
@@ -2,6 +2,8 @@ use heapless::String;
 
 use super::{AtParseErr, AtParseLine, AtRequest, AtResponse, GenericOk, ResponseCode};
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct ShowIccid;
 
 impl AtRequest for ShowIccid {

--- a/sim7000-async/src/at_command/cedrxs.rs
+++ b/sim7000-async/src/at_command/cedrxs.rs
@@ -5,6 +5,8 @@ use super::{AtRequest, GenericOk};
 
 #[repr(u8)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum EDRXSetting {
     Disable = 0,
     Enable = 1,
@@ -13,6 +15,8 @@ pub enum EDRXSetting {
 
 #[repr(u8)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum AcTType {
     CatM = 4,
     NbIot = 5,
@@ -20,6 +24,8 @@ pub enum AcTType {
 
 /// AT+CEDRX=...
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct ConfigureEDRX {
     pub n: EDRXSetting,
     pub act_type: AcTType,

--- a/sim7000-async/src/at_command/cfgri.rs
+++ b/sim7000-async/src/at_command/cfgri.rs
@@ -5,6 +5,8 @@ use super::{AtRequest, GenericOk};
 
 #[repr(u8)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum RiPinMode {
     Off = 0,
     On = 1,
@@ -12,6 +14,8 @@ pub enum RiPinMode {
 }
 
 /// AT+CFGRI=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct ConfigureRiPin(pub RiPinMode);
 
 impl AtRequest for ConfigureRiPin {

--- a/sim7000-async/src/at_command/cgnspwr.rs
+++ b/sim7000-async/src/at_command/cgnspwr.rs
@@ -4,6 +4,8 @@ use heapless::String;
 use super::{AtRequest, GenericOk};
 
 /// AT+CGNSPWR=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct SetGnssPower(pub bool);
 
 impl AtRequest for SetGnssPower {

--- a/sim7000-async/src/at_command/cgnsurc.rs
+++ b/sim7000-async/src/at_command/cgnsurc.rs
@@ -4,6 +4,8 @@ use heapless::String;
 use super::{AtRequest, GenericOk};
 
 /// AT+CGNSURC=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct ConfigureGnssUrc {
     /// Send URC report every <n> GNSS fix.
     /// Set to 0 to disable.

--- a/sim7000-async/src/at_command/cgreg.rs
+++ b/sim7000-async/src/at_command/cgreg.rs
@@ -8,6 +8,8 @@ use super::{AtRequest, GenericOk};
 /// Configure network registration URC
 #[repr(u8)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum ConfigureRegistrationUrc {
     /// Disable URC
     Disable = 0,
@@ -22,6 +24,8 @@ pub enum ConfigureRegistrationUrc {
 }
 
 /// AT+CGREG?
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct GetRegistrationStatus;
 
 impl AtRequest for ConfigureRegistrationUrc {

--- a/sim7000-async/src/at_command/cifsrex.rs
+++ b/sim7000-async/src/at_command/cifsrex.rs
@@ -5,6 +5,8 @@ use crate::util::collect_array;
 use super::{AtParseErr, AtParseLine, AtRequest, AtResponse, GenericOk, ResponseCode};
 
 /// AT+CIFSREX
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct GetLocalIpExt;
 
 impl AtRequest for GetLocalIpExt {

--- a/sim7000-async/src/at_command/ciicr.rs
+++ b/sim7000-async/src/at_command/ciicr.rs
@@ -3,6 +3,8 @@ use heapless::String;
 use super::{AtRequest, GenericOk};
 
 /// AT+CIICR
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct StartGprs;
 
 impl AtRequest for StartGprs {

--- a/sim7000-async/src/at_command/cipclose.rs
+++ b/sim7000-async/src/at_command/cipclose.rs
@@ -4,6 +4,8 @@ use heapless::String;
 use super::{AtRequest, CloseOk};
 
 /// AT+CIPCLOSE=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct CloseConnection {
     pub connection: usize,
 }

--- a/sim7000-async/src/at_command/cipmux.rs
+++ b/sim7000-async/src/at_command/cipmux.rs
@@ -3,6 +3,8 @@ use heapless::String;
 use super::{AtRequest, GenericOk};
 
 /// AT+CIPMUX=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct EnableMultiIpConnection(pub bool);
 
 impl AtRequest for EnableMultiIpConnection {

--- a/sim7000-async/src/at_command/cipsend.rs
+++ b/sim7000-async/src/at_command/cipsend.rs
@@ -4,6 +4,8 @@ use heapless::String;
 use super::{AtRequest, WritePrompt};
 
 /// AT+CIPSEND
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct IpSend {
     pub connection: usize,
     pub data_length: usize,

--- a/sim7000-async/src/at_command/cipshut.rs
+++ b/sim7000-async/src/at_command/cipshut.rs
@@ -3,6 +3,8 @@ use heapless::String;
 use super::{AtRequest, GenericOk};
 
 /// AT+CIPSHUT
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct ShutConnections;
 
 impl AtRequest for ShutConnections {

--- a/sim7000-async/src/at_command/cipsprt.rs
+++ b/sim7000-async/src/at_command/cipsprt.rs
@@ -6,6 +6,8 @@ use super::{AtRequest, GenericOk};
 /// AT+CIPSPRT=...
 #[repr(u8)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum SetCipSendPrompt {
     /// Send SEND OK but do not send "> " prompt
     ResponseNoPrompt = 0,

--- a/sim7000-async/src/at_command/cipstart.rs
+++ b/sim7000-async/src/at_command/cipstart.rs
@@ -3,12 +3,16 @@ use heapless::String;
 
 use super::{AtRequest, GenericOk};
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum ConnectMode {
     Tcp,
     Udp,
 }
 
 /// AT+CIPSTART=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct Connect {
     /// Which connection slot to use (Multi-IP mode)
     pub number: usize,
@@ -17,6 +21,7 @@ pub struct Connect {
     pub mode: ConnectMode,
 
     /// IP or domain name
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     pub destination: String<100>,
 
     pub port: u16,

--- a/sim7000-async/src/at_command/cmee.rs
+++ b/sim7000-async/src/at_command/cmee.rs
@@ -5,6 +5,8 @@ use super::{AtRequest, GenericOk};
 
 #[repr(u8)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum CMEErrorMode {
     Disable = 0,
     Numeric = 1,
@@ -12,6 +14,8 @@ pub enum CMEErrorMode {
 }
 
 /// AT+CMEE=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct ConfigureCMEErrors(pub CMEErrorMode);
 
 impl AtRequest for ConfigureCMEErrors {

--- a/sim7000-async/src/at_command/cmnb.rs
+++ b/sim7000-async/src/at_command/cmnb.rs
@@ -5,6 +5,8 @@ use super::{AtRequest, GenericOk};
 
 #[repr(u8)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum NbMode {
     CatM = 1,
     NbIot = 2,
@@ -12,6 +14,8 @@ pub enum NbMode {
 }
 
 /// AT+CMNB=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct SetNbMode(pub NbMode);
 
 impl AtRequest for SetNbMode {

--- a/sim7000-async/src/at_command/cnmp.rs
+++ b/sim7000-async/src/at_command/cnmp.rs
@@ -5,6 +5,8 @@ use super::{AtRequest, GenericOk};
 
 #[repr(u8)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum NetworkMode {
     Automatic = 2,
     Gsm = 13,
@@ -13,6 +15,8 @@ pub enum NetworkMode {
 }
 
 /// AT+CNMP=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct SetNetworkMode(pub NetworkMode);
 
 impl AtRequest for SetNetworkMode {

--- a/sim7000-async/src/at_command/cops.rs
+++ b/sim7000-async/src/at_command/cops.rs
@@ -4,6 +4,9 @@ use crate::util::collect_array;
 
 use super::{AtParseErr, AtParseLine, AtRequest, AtResponse, GenericOk, ResponseCode};
 
+/// AT+COPS?
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct GetOperatorInfo;
 
 #[derive(Debug)]

--- a/sim7000-async/src/at_command/cpsi.rs
+++ b/sim7000-async/src/at_command/cpsi.rs
@@ -4,6 +4,9 @@ use crate::util::collect_array;
 
 use super::{AtParseErr, AtParseLine, AtRequest, AtResponse, GenericOk, ResponseCode};
 
+/// AT+CPSI?
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct GetSystemInfo;
 
 impl AtRequest for GetSystemInfo {

--- a/sim7000-async/src/at_command/csclk.rs
+++ b/sim7000-async/src/at_command/csclk.rs
@@ -2,6 +2,9 @@ use heapless::String;
 
 use super::{AtRequest, GenericOk};
 
+/// AT+CSCLK=<1 or 0>
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct SetSlowClock(pub bool);
 
 impl AtRequest for SetSlowClock {

--- a/sim7000-async/src/at_command/csq.rs
+++ b/sim7000-async/src/at_command/csq.rs
@@ -3,6 +3,8 @@ use heapless::String;
 use super::{AtParseErr, AtParseLine, AtRequest, AtResponse, GenericOk, ResponseCode};
 
 /// AT+CSQ
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct GetSignalQuality;
 
 impl AtRequest for GetSignalQuality {

--- a/sim7000-async/src/at_command/cstt.rs
+++ b/sim7000-async/src/at_command/cstt.rs
@@ -4,9 +4,16 @@ use heapless::String;
 use super::{AtRequest, GenericOk};
 
 /// AT+CSTT=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct StartTask {
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     pub apn: String<50>,
+
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     pub username: String<50>,
+
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     pub password: String<50>,
 }
 

--- a/sim7000-async/src/at_command/generic_response.rs
+++ b/sim7000-async/src/at_command/generic_response.rs
@@ -47,11 +47,11 @@ impl AtResponse for GenericOk {
 
 impl AtParseLine for SimError {
     fn from_line(line: &str) -> Result<Self, AtParseErr> {
-        if let Some(code) = line.strip_prefix("+CME ERROR") {
+        if let Some(code) = line.strip_prefix("+CME ERROR: ") {
             Ok(SimError::CmeErr {
                 code: code.parse()?,
             })
-        } else if let Some(code) = line.strip_prefix("+CMS ERROR") {
+        } else if let Some(code) = line.strip_prefix("+CMS ERROR: ") {
             Ok(SimError::CmsErr {
                 code: code.parse()?,
             })

--- a/sim7000-async/src/at_command/ifc.rs
+++ b/sim7000-async/src/at_command/ifc.rs
@@ -5,6 +5,8 @@ use super::{AtRequest, GenericOk};
 
 /// AT+IFC=...
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct SetFlowControl {
     pub dce_by_dte: FlowControl,
     pub dte_by_dce: FlowControl,
@@ -12,6 +14,8 @@ pub struct SetFlowControl {
 
 #[repr(u8)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum FlowControl {
     NoFlowControl = 0,
     Software = 1,

--- a/sim7000-async/src/at_command/ipr.rs
+++ b/sim7000-async/src/at_command/ipr.rs
@@ -5,6 +5,8 @@ use super::{AtRequest, GenericOk};
 
 #[repr(u32)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub enum BaudRate {
     Hz0 = 0,
     Hz300 = 300,
@@ -28,6 +30,8 @@ pub enum BaudRate {
 }
 
 /// AT+IPR=...
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 pub struct SetBaudRate(pub BaudRate);
 
 impl AtRequest for SetBaudRate {

--- a/sim7000-async/src/at_command/mod.rs
+++ b/sim7000-async/src/at_command/mod.rs
@@ -1,4 +1,7 @@
-use core::num::{ParseFloatError, ParseIntError};
+use core::{
+    fmt::Debug,
+    num::{ParseFloatError, ParseIntError},
+};
 
 pub mod generic_response;
 pub mod unsolicited;
@@ -71,7 +74,14 @@ pub(crate) trait AtParseLine: Sized {
     fn from_line(line: &str) -> Result<Self, AtParseErr>;
 }
 
-pub trait AtRequest {
+#[cfg(feature = "defmt")]
+pub trait AtRequest: defmt::Format {
+    type Response;
+    fn encode(&self) -> heapless::String<256>;
+}
+
+#[cfg(not(feature = "defmt"))]
+pub trait AtRequest: Debug {
     type Response;
     fn encode(&self) -> heapless::String<256>;
 }

--- a/sim7000-async/src/read.rs
+++ b/sim7000-async/src/read.rs
@@ -24,8 +24,8 @@ impl<'context> ModemReader<'context> {
         loop {
             if !self.buffer.is_empty() {
                 match from_utf8(&self.buffer) {
-                    Ok(line) => log::debug!("CURRENT BUFFER {:?}", line),
-                    Err(_) => log::debug!("INVALID UTF-8 {:?}", self.buffer.as_slice()),
+                    Ok(line) => log::trace!("CURRENT BUFFER (utf-8) {:?}", line),
+                    Err(_) => log::trace!("CURRENT BUFFER (binary) {:?}", self.buffer.as_slice()),
                 }
             }
 
@@ -57,7 +57,7 @@ impl<'context> ModemReader<'context> {
                         return Err(err);
                     }
                 };
-                log::debug!("RECV LINE: {:?}", line);
+                log::trace!("RECV LINE: {:?}", line);
 
                 // Ignore empty lines, as well as echoed lines ending with just a CR
                 if line.trim().is_empty() || line.ends_with('\r') {

--- a/sim7000-async/src/tcp.rs
+++ b/sim7000-async/src/tcp.rs
@@ -222,16 +222,16 @@ impl<'s> Read for TcpReader<'s> {
             }
 
             loop {
-                log::info!("tcp {} awaiting rx/event", stream.token.ordinal());
+                log::trace!("tcp {} awaiting rx/event", stream.token.ordinal());
 
                 futures::select_biased! {
                     _ = stream.handle_events().fuse() => unreachable!(),
                     n = stream.token.rx().read(buf).fuse() => {
-                        log::info!("tcp {} rx got {} bytes", stream.token.ordinal(), n);
+                        log::trace!("tcp {} rx got {} bytes", stream.token.ordinal(), n);
                         break Ok(n);
                     }
                     event = events.next_message_pure().fuse() => {
-                        log::info!("tcp {} got event {:?}", stream.token.ordinal(), event);
+                        log::trace!("tcp {} got event {:?}", stream.token.ordinal(), event);
                         if event == ConnectionMessage::Closed {
                             stream.closed.store(true, Ordering::Release);
                             break Ok(0);


### PR DESCRIPTION
- Make logging generally less verbose (change some `log::info`s to `log::debug`s, etc)
- Add ATRequest: Debug bound (or `defmt::Format` if `defmt` feature is enabled)
- Add error log on failed AT commands, telling us what command failed
- Fix parsing of CMS and CME error codes