### PR TITLE
Avoid using FromStr for parsing floats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ log = { version = "0.4", optional = true }
 default = ["log"]
 log = ["dep:log"]
 defmt = ["dep:defmt",  "embassy-time/defmt", "heapless/defmt-impl"]
+
+[dev-dependencies]
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"

--- a/src/at_command/mod.rs
+++ b/src/at_command/mod.rs
@@ -1,6 +1,6 @@
 use core::{
     fmt::Debug,
-    num::{ParseFloatError, ParseIntError},
+    num::{IntErrorKind, ParseFloatError, ParseIntError},
 };
 
 pub mod generic_response;
@@ -177,6 +177,14 @@ impl AtParseLine for ResponseCode {
 impl From<&'static str> for AtParseErr {
     fn from(message: &'static str) -> Self {
         AtParseErr { message }
+    }
+}
+
+impl From<IntErrorKind> for AtParseErr {
+    fn from(_: IntErrorKind) -> Self {
+        AtParseErr {
+            message: "Failed to parse integer",
+        }
     }
 }
 


### PR DESCRIPTION
f32s FromStr impl is very bloated, although probably faster than this solution. This solution results in about 18KB less flash usage for the nrf sample crate though.